### PR TITLE
Different release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,18 @@ All requests should be made to the `/graphql` endpoint (e.g., `http://localhost:
 
 ### Fetching a specific or random movie
 
-| Parameter | Type     | Description                                                                 |
-| :-------- | :------- | :-------------------------------------------------------------------------- |
-| `imdbId`  | `string` | Optionally. IMDb ID, uniquely identifies a movie.                           |
-| `num`     | `int`    | Optionally. Specifies how many additional random movies should be returned. |
+| Parameter              | Type      | Default | Description                                                                                                  |
+| :--------------------- | :-------- | :------ | :----------------------------------------------------------------------------------------------------------- |
+| `imdbId`               | `string`  | `-`     | Optional. IMDb ID, uniquely identifies a movie.                                                              |
+| `randomMovies`         | `field`   | `-`     | Optional. Specifies that one or multiple additional random movie(s) should be returned.                      |
+| `num`                  | `int`     | `1`     | Optional. Specifies how many additional random movies should be returned.                                    |
+| `differentReleaseYear` | `boolean` | `false` | Optional. Specifies whether the random movie(s) should have a different release year than the specified one. |
 
 _Note:_
 
 - _If `imdbId` is used, a specific movie is returned. If the parameter is not added, a random movie is returned._
 - _If `randomMovies` is added but no `num` is specified, one additional random movie is returned. `randomMovies` can completely be omitted, so that no additional random moves are returned._
+- _If `differentReleaseYear` is added but no `imdbId` is specified, `differentReleaseYear` will not be considered._
 
 **Example**
 
@@ -67,7 +70,7 @@ Request:
 query {
   movie(imdbId: "tt1431045") {
     imdbId title releaseYear posterPath
-    randomMovies(num: 3) { imdbId title releaseYear posterPath }
+    randomMovies(num: 3, differentReleaseYear: true) { imdbId title releaseYear posterPath }
   }
 }
 ```

--- a/src/movie/movie.graphql
+++ b/src/movie/movie.graphql
@@ -3,7 +3,7 @@ type Movie {
   title: String!
   releaseYear: Int!
   posterPath: String!
-  randomMovies(num: Int): [Movie!]
+  randomMovies(num: Int, differentReleaseYear: Boolean): [Movie!]
 }
 
 type Query {

--- a/src/movie/movie.resolver.ts
+++ b/src/movie/movie.resolver.ts
@@ -23,7 +23,12 @@ export class MovieResolver {
   async randomMovies(
     @Parent() movie: Movie,
     @Args('num') num: number = 1,
+    @Args('differentReleaseYear') differentReleaseYear: boolean = false,
   ): Promise<Movie[]> {
-    return this.movieService.getRandomMovies(num, movie.imdbId)
+    return this.movieService.getRandomMovies(
+      num,
+      movie.imdbId,
+      differentReleaseYear ? movie.releaseYear : 0,
+    )
   }
 }

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -32,7 +32,12 @@ export class MovieService {
     differentReleaseYear: number = 0,
   ): Promise<Movie[]> {
     try {
-      const metadata = await this.getMetadata(null, numMovies, differentFrom, differentReleaseYear)
+      const metadata = await this.getMetadata(
+        null,
+        numMovies,
+        differentFrom,
+        differentReleaseYear,
+      )
       const posters = await Promise.all(
         metadata.map((m) => this.getPoster(m.imdbId)),
       )
@@ -66,7 +71,7 @@ export class MovieService {
       imdbId,
       numMovies,
       differentFrom,
-      differentReleaseYear
+      differentReleaseYear,
     )
     const metadataResponse = await axios.get(metadataUrl)
     return Utils.extractDataFromMetadataResponse(metadataResponse)

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -29,9 +29,10 @@ export class MovieService {
   async getRandomMovies(
     numMovies: number = 1,
     differentFrom: string = null,
+    differentReleaseYear: number = 0,
   ): Promise<Movie[]> {
     try {
-      const metadata = await this.getMetadata(null, numMovies, differentFrom)
+      const metadata = await this.getMetadata(null, numMovies, differentFrom, differentReleaseYear)
       const posters = await Promise.all(
         metadata.map((m) => this.getPoster(m.imdbId)),
       )
@@ -59,11 +60,13 @@ export class MovieService {
     imdbId: string = null,
     numMovies: number = 1,
     differentFrom: string = null,
+    differentReleaseYear: number = 0,
   ): Promise<Partial<Movie[]>> {
     const metadataUrl = Utils.buildMetadataServiceURL(
       imdbId,
       numMovies,
       differentFrom,
+      differentReleaseYear
     )
     const metadataResponse = await axios.get(metadataUrl)
     return Utils.extractDataFromMetadataResponse(metadataResponse)

--- a/src/movie/movie.utils.ts
+++ b/src/movie/movie.utils.ts
@@ -10,6 +10,7 @@ export const buildMetadataServiceURL = (
   imdbId: string = null,
   numMovies: number = 1,
   differentFrom: string = null,
+  differentReleaseYear: number = 0
 ): string => {
   const metadataURL = new URL(`${process.env.METADATA_SERVICE_URL}`)
 
@@ -24,6 +25,10 @@ export const buildMetadataServiceURL = (
   // the returned movie(s) should not include the movie with imdbId `differentFrom`
   differentFrom &&
     metadataURL.searchParams.append('differentFrom', `${differentFrom}`)
+  
+  // the returned movie(s) should not be released in the same year as the movie with imdbId `differentFrom` 
+  differentFrom && differentReleaseYear &&
+    metadataURL.searchParams.append('notReleasedIn', `${differentReleaseYear}`)
 
   return metadataURL.href
 }

--- a/src/movie/movie.utils.ts
+++ b/src/movie/movie.utils.ts
@@ -10,7 +10,7 @@ export const buildMetadataServiceURL = (
   imdbId: string = null,
   numMovies: number = 1,
   differentFrom: string = null,
-  differentReleaseYear: number = 0
+  differentReleaseYear: number = 0,
 ): string => {
   const metadataURL = new URL(`${process.env.METADATA_SERVICE_URL}`)
 
@@ -25,9 +25,10 @@ export const buildMetadataServiceURL = (
   // the returned movie(s) should not include the movie with imdbId `differentFrom`
   differentFrom &&
     metadataURL.searchParams.append('differentFrom', `${differentFrom}`)
-  
-  // the returned movie(s) should not be released in the same year as the movie with imdbId `differentFrom` 
-  differentFrom && differentReleaseYear &&
+
+  // the returned movie(s) should not be released in the same year as the movie with imdbId `differentFrom`
+  differentFrom &&
+    differentReleaseYear &&
     metadataURL.searchParams.append('notReleasedIn', `${differentReleaseYear}`)
 
   return metadataURL.href

--- a/test/movie/movie.e2e.spec.ts
+++ b/test/movie/movie.e2e.spec.ts
@@ -131,6 +131,43 @@ describe.skip('Movie Resolver (e2e)', () => {
         let randomMovie = movie.randomMovies[0]
         expect(randomMovie.imdbId).not.toBe(MOVIE.imdbId)
         expect(randomMovie.title).not.toBe(MOVIE.title)
+        //expect(randomMovie.releaseYear).not.toBe(MOVIE.releaseYear)
+        expect(randomMovie.posterPath).not.toBe(MOVIE.posterPath)
+
+        randomMovie = movie.randomMovies[1]
+        expect(randomMovie.imdbId).not.toBe(MOVIE.imdbId)
+        expect(randomMovie.title).not.toBe(MOVIE.title)
+        //expect(randomMovie.releaseYear).not.toBe(MOVIE.releaseYear)
+        expect(randomMovie.posterPath).not.toBe(MOVIE.posterPath)
+      })
+  })
+
+  it('should return a specific movie with two random movies not released in the same year as the specified movie', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: `
+        {
+          movie(imdbId: "tt2395427") {
+            imdbId title releaseYear posterPath
+            randomMovies(num: 2, differentReleaseYear: true) {imdbId title releaseYear posterPath}
+          }
+        }
+        `,
+      })
+      .expect(200)
+      .then((response) => {
+        const movie = response.body.data.movie
+        expect(movie.imdbId).toBe(MOVIE.imdbId)
+        expect(movie.title).toBe(MOVIE.title)
+        expect(movie.releaseYear).toBe(MOVIE.releaseYear)
+        expect(movie.posterPath).toBe(MOVIE.posterPath)
+
+        expect(movie.randomMovies.length).toBe(2)
+
+        let randomMovie = movie.randomMovies[0]
+        expect(randomMovie.imdbId).not.toBe(MOVIE.imdbId)
+        expect(randomMovie.title).not.toBe(MOVIE.title)
         expect(randomMovie.releaseYear).not.toBe(MOVIE.releaseYear)
         expect(randomMovie.posterPath).not.toBe(MOVIE.posterPath)
 

--- a/test/movie/movie.utils.spec.ts
+++ b/test/movie/movie.utils.spec.ts
@@ -29,6 +29,24 @@ describe('MovieUtils', () => {
     )
   })
 
+  it('should build the metadata service url that returns data for three random movies (no other filters like `differentFrom`)', async () => {
+    expect(Utils.buildMetadataServiceURL(null, 3, null)).toBe(
+      `${METADATA_SERVICE}/?numMovies=3`,
+    )
+  })
+
+  it('should build the metadata service url that returns data for three random movies where a specific movie may not be included and must be released in a different year', async () => {
+    expect(Utils.buildMetadataServiceURL(null, 3, 'tt3450958', 2016)).toBe(
+      `${METADATA_SERVICE}/?numMovies=3&differentFrom=tt3450958&notReleasedIn=2016`,
+    )
+  })
+
+  it('should build the metadata service url that returns data for three random movies (no other filters like `differentFrom` or `notReleasedIn`)', async () => {
+    expect(Utils.buildMetadataServiceURL(null, 3, null, 0)).toBe(
+      `${METADATA_SERVICE}/?numMovies=3`,
+    )
+  })
+
   it('should build the metadata service url that returns data for a specific movie', async () => {
     expect(Utils.buildMetadataServiceURL('tt2395427')).toBe(
       `${METADATA_SERVICE}/?imdbId=tt2395427`,


### PR DESCRIPTION
### Description

Extend `movie` query to specify whether the random movies should have a different release year than the specified movie.

This change is directly integrated in the existing field of `movie` and not as a separate one as initially specified in #29. It is implemented as follows:
```
query {
  movie(imdbId: "tt1431045") {
    imdbId title releaseYear posterPath
    randomMovies(num: 2, differentReleaseYear: true) {
      imdbId title releaseYear posterPath
    }
  }
}

```

### Related Issues

#29 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo
