### PR TITLE
Extend Movie Query with revenue, budget and popularity

### DIFF
--- a/src/movie/movie.graphql
+++ b/src/movie/movie.graphql
@@ -3,6 +3,9 @@ type Movie {
   title: String!
   releaseYear: Int!
   posterPath: String!
+  budget: Int
+  revenue: Int
+  popularity: Float
   randomMovies(num: Int, differentReleaseYear: Boolean): [Movie!]
 }
 

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -51,6 +51,9 @@ export class MovieService {
           title: m.title,
           releaseYear: m.releaseYear,
           posterPath: posters[i].posterPath,
+          budget: m.budget,
+          revenue: m.revenue,
+          popularity: m.popularity,
         }
       })
     } catch (error) {

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -20,6 +20,9 @@ export class MovieService {
         title: metadata.title,
         releaseYear: metadata.releaseYear,
         posterPath: poster.posterPath,
+        budget: metadata.budget,
+        revenue: metadata.revenue,
+        popularity: metadata.popularity,
       }
     } catch (error) {
       Utils.handleError(error)

--- a/src/movie/movie.utils.ts
+++ b/src/movie/movie.utils.ts
@@ -40,6 +40,9 @@ export const extractDataFromMetadataResponse = (response): Partial<Movie[]> => {
       imdbId: movie.imdb_id,
       title: movie.title,
       releaseYear: parseInt(movie.release_year),
+      budget: parseInt(movie.budget),
+      revenue: parseInt(movie.revenue),
+      popularity: movie.popularity,
     }
   })
 }

--- a/test/movie/movie.utils.spec.ts
+++ b/test/movie/movie.utils.spec.ts
@@ -109,6 +109,9 @@ describe('MovieUtils', () => {
       imdbId: 'tt2395427',
       title: 'Avengers: Age of Ultron',
       releaseYear: 2015,
+      revenue: 1405403694,
+      budget: 280000000,
+      popularity: 37.37942,
     }
     const actual: Partial<Movie> = Utils.extractDataFromMetadataResponse(
       response,


### PR DESCRIPTION
### Description

This PR extends the API to return additional metadata about a movie such as: revenue, budget and popularity

### Related Issues

#117 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this PR

